### PR TITLE
[WIP] LLVM Instrinsics

### DIFF
--- a/src/Libm.jl
+++ b/src/Libm.jl
@@ -1,5 +1,5 @@
 module Libm
 
-# package code goes here
+include("llvm_math.jl")
 
 end # module

--- a/src/llvm_math.jl
+++ b/src/llvm_math.jl
@@ -1,0 +1,53 @@
+using Base: llvmcall
+
+function _llvm_ufun(name, jltype::Type, llvmtype, suffix)
+	declarations = """declare $llvmtype @llvm.$name.$suffix($llvmtype)"""
+	body = """%2 = call $llvmtype @llvm.$name.$suffix($llvmtype %0)
+			   ret $llvmtype %2"""
+	quote
+		function $name(x::$jltype)
+			llvmcall(($declarations, $body),
+					$jltype, Tuple{$jltype}, x)
+	   end
+	end
+end
+
+
+function _llvm_bfun(name, jltype::Type, llvmtype, suffix)
+	declarations = """declare $llvmtype @llvm.$name.$suffix($llvmtype, $llvmtype)"""
+	body = """%3 = call $llvmtype @llvm.$name.$suffix($llvmtype %0, $llvmtype %1)
+			   ret $llvmtype %3"""
+	quote
+		function $name(x::$jltype, y::$jltype)
+			llvmcall(($declarations, $body),
+					$jltype, Tuple{$jltype,$jltype}, x, y)
+	   end
+	end
+end
+
+
+
+# uniry functions
+for fun in [
+		:sin,:cos, :exp,:exp2,:log, :log10, :log2,
+		:sqrt, :fabs, :ceil, :floor, :trunc, :round, :rint, :nearbyint
+		]
+	eval(_llvm_ufun(fun, Float64, :double, :f64))
+	eval(_llvm_ufun(fun, Float32, :float, :f32))
+end
+
+
+# binary functions
+for fun in [:pow, :maxnum, :minnum]
+	eval(_llvm_bfun(fun, Float64, :double, :f64))
+	eval(_llvm_bfun(fun, Float32, :float, :f32))
+end
+
+const fmax=maxnum
+const fmin=minnum
+
+
+#const remainder=rem=frem
+
+
+

--- a/test/llvm_math.jl
+++ b/test/llvm_math.jl
@@ -1,0 +1,52 @@
+using Base.Test
+using Libm
+
+libmfun(fun) = eval(:(Libm.$fun))
+basefun(fun) = eval(:(Base.$fun))
+
+
+query_points = [0.5,1.0, 1.3, 1.33, 2.0, 5.0, 100.0 ,256.0, 1000.0, 2000.0]
+
+
+# uniry functions
+for fun in [
+		:sin,:cos,
+		:exp,:exp2, :log, :log10, :log2,
+		:sqrt, :fabs, :ceil, :floor, :trunc, :round, :rint, :nearbyint
+		]
+
+	@testset "$fun" begin
+		ourfun = libmfun(fun)
+		stdfun = basefun(fun)
+
+		for val in query_points
+			@test ourfun(val) == stdfun(val)
+			@test ourfun(Float32(val)) == stdfun(Float32(val))
+
+			if fun ∉ [:log,:log10,:log2]
+				@test ourfun(-val) == stdfun(-val)
+				@test ourfun(Float32(-val)) == stdfun(Float32(-val))
+			end
+		end
+	end
+
+end
+
+query_points2 = [-query_points; query_points ]
+# binary functions
+for fun in [:pow, :maxnum, :minnum]
+
+	@testset "$fun" begin
+		ourfun = libmfun(fun)
+		stdfun = basefun(fun)
+
+		for val1 in query_points2
+			for val2 in query_points2
+			@test ourfun(val1, val2) == stdfun(val1, val2)
+			@test ourfun(Float32(val1),Float32(val2)) == stdfun(Float32(val1),Float32(val2))
+		end
+	end
+end
+
+
+

--- a/test/llvm_math.jl
+++ b/test/llvm_math.jl
@@ -8,45 +8,48 @@ basefun(fun) = eval(:(Base.$fun))
 query_points = [0.5,1.0, 1.3, 1.33, 2.0, 5.0, 100.0 ,256.0, 1000.0, 2000.0]
 
 
+#TODO: test fabs, rint, nearbyint
+
+#@testset "round" begin
+#	@test_broken Libm.round(0.5) == 0.0
+#end
+
 # uniry functions
-for fun in [
-		:sin,:cos,
-		:exp,:exp2, :log, :log10, :log2,
-		:sqrt, :fabs, :ceil, :floor, :trunc, :round, :rint, :nearbyint
-		]
+@testset "$fun" for fun in [
+	:sin,:cos,
+	:exp,:exp2, :log, :log10, :log2,
+	:sqrt, :ceil, :floor, :trunc
+	]
 
-	@testset "$fun" begin
-		ourfun = libmfun(fun)
-		stdfun = basefun(fun)
 
-		for val in query_points
-			@test ourfun(val) == stdfun(val)
-			@test ourfun(Float32(val)) == stdfun(Float32(val))
+	ourfun = libmfun(fun)
+	stdfun = basefun(fun)
 
-			if fun ∉ [:log,:log10,:log2]
-				@test ourfun(-val) == stdfun(-val)
-				@test ourfun(Float32(-val)) == stdfun(Float32(-val))
-			end
-		end
-	end
+	for val in query_points
+		@test ourfun(val) == stdfun(val)
+		@test ourfun(Float32(val)) == stdfun(Float32(val))
 
-end
-
-query_points2 = [-query_points; query_points ]
-# binary functions
-for fun in [:pow, :maxnum, :minnum]
-
-	@testset "$fun" begin
-		ourfun = libmfun(fun)
-		stdfun = basefun(fun)
-
-		for val1 in query_points2
-			for val2 in query_points2
-			@test ourfun(val1, val2) == stdfun(val1, val2)
-			@test ourfun(Float32(val1),Float32(val2)) == stdfun(Float32(val1),Float32(val2))
+		if fun ∉ [:log,:log10,:log2,:sqrt]
+			@test ourfun(-val) == stdfun(-val)
+			@test ourfun(Float32(-val)) == stdfun(Float32(-val))
 		end
 	end
 end
 
+#TODO: Test fmax and fmin
+
+@testset "pow" begin
+	@test Libm.pow(1.0,2.0) == 1.0
+	@test Libm.pow(10.0,0.0) == 1.0
+	@test Libm.pow(2.0,2.0) == 4.0
+	@test Libm.pow(2.0,0.5) == sqrt(2.)
+
+	@test Libm.pow(1f0,2f0) == 1f0
+	@test Libm.pow(10f0,0f0) == 1f0
+	@test Libm.pow(2f0,2f0) == 4f0
+	@test Libm.pow(2f0,0.5f0) == sqrt(2f0)
+
+
+end
 
 


### PR DESCRIPTION
LLVM has a (slightly eclectic) collection of Floating point operations defined.
See the [LLVM manual](http://llvm.org/docs/LangRef.html#standard-c-library-intrinsics)

 We have:
-  `sin`,  `cos`, `exp`, `exp2`, `log`, `log10`, `log2`,
-  and the already noted: `sqrt`, `fabs`, `ceil`, `floor`, `trunc`, `round`, `rint`, `nearbyint`
-  `pow`, `fmax` (llvm: `maxnum`), `fmin` (llvm: `minnum`)

I don't really know their provenance, not their accuracy/performance characteristics.
Testing is on going to determine those.
At least on a superficial basis, all seem to be working.

Actual accuracy and performance testing, still pending.

Using the things LLVM does define, it is not too hard to leverage to get another half dozen things by simple operations -- but they too would certainly need accuracy and performance testing

Anyway, I wanted to put their existence out there, and put them in a way we can easily call them
