### PR TITLE
Drop v0.5 pre-release support

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5-
+julia 0.5
 Reexport

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
 julia 0.5
-Reexport


### PR DESCRIPTION
I think it would be sane to drop support for v0.5 pre-releases now that v0.5 is released. This likely won't be an issue for anyone, but I think it's just good form to make sure there's no issue here. Also, this would likely come up when registering in METADATA (I know this is one of the things which are checked), so it might as well be fixed now.
